### PR TITLE
TDEPS-56 Main opts with space broken apart

### DIFF
--- a/src/main/clojure/clojure/tools/deps/alpha/script/make_classpath.clj
+++ b/src/main/clojure/clojure/tools/deps/alpha/script/make_classpath.clj
@@ -76,7 +76,9 @@
         (when (.exists jf)
           (.delete jf))))
     (if-let [main-opts (seq (get (deps/combine-aliases deps-map (concat aliases main-aliases)) :main-opts))]
-      (io/write-file main-file (str/join " " main-opts))
+      (io/write-file main-file (str/join " " (map (fn [s]
+                                                    (str/replace s #"(.)" "\\\\$1"))
+                                                  main-opts)))
       (let [mf (jio/file main-file)]
         (when (.exists mf)
           (.delete mf))))))


### PR DESCRIPTION
Quote all characters in arguments so that arguments containing
whitespce aren't broken aprt. For simplicity, use backslash escaping,
which works with any character.

Requires a sibling patch in the brew-install repository.